### PR TITLE
WTWindowsTimers can now be initialized with a custom queue

### DIFF
--- a/WindowTimers/WindowTimers.h
+++ b/WindowTimers/WindowTimers.h
@@ -4,6 +4,7 @@
 
 @interface WTWindowTimers : NSObject
 
+- (instancetype)init;
 - (instancetype)initWithDispatchQueue:(dispatch_queue_t)queue;
 
 - (void)extend:(id)context;

--- a/WindowTimers/WindowTimers.h
+++ b/WindowTimers/WindowTimers.h
@@ -4,6 +4,8 @@
 
 @interface WTWindowTimers : NSObject
 
+- (instancetype)initWithDispatchQueue:(dispatch_queue_t)queue;
+
 - (void)extend:(id)context;
 
 // TODO proper types

--- a/WindowTimers/WindowTimers.m
+++ b/WindowTimers/WindowTimers.m
@@ -6,10 +6,10 @@
     NSMapTable *_dispatchSourcesMapping;
 }
 
-- (instancetype)init {
+- (instancetype)initWithDispatchQueue:(dispatch_queue_t)queue {
     if (self = [super init]) {
         _timeoutCounter = 0;
-        _queue = dispatch_get_main_queue();
+        _queue = queue;//dispatch_get_main_queue();
         _dispatchSourcesMapping = [NSMapTable weakToWeakObjectsMapTable];
         self.tolerance = 10;
     }

--- a/WindowTimers/WindowTimers.m
+++ b/WindowTimers/WindowTimers.m
@@ -13,7 +13,7 @@
 - (instancetype)initWithDispatchQueue:(dispatch_queue_t)queue {
     if (self = [super init]) {
         _timeoutCounter = 0;
-        _queue = queue;//dispatch_get_main_queue();
+        _queue = queue;
         _dispatchSourcesMapping = [NSMapTable weakToWeakObjectsMapTable];
         self.tolerance = 10;
     }

--- a/WindowTimers/WindowTimers.m
+++ b/WindowTimers/WindowTimers.m
@@ -6,6 +6,10 @@
     NSMapTable *_dispatchSourcesMapping;
 }
 
+- (instancetype)init {
+    return [self initWithDispatchQueue:dispatch_get_main_queue()];
+}
+
 - (instancetype)initWithDispatchQueue:(dispatch_queue_t)queue {
     if (self = [super init]) {
         _timeoutCounter = 0;


### PR DESCRIPTION
Instead of always using the main dispatch queue, a custom queue can now be specified to handle timers events. 